### PR TITLE
Make security group rule maximum configurable (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ usage: sync-pingdom-ec2-security-groups.py [-h] [--profile PROFILE]
                                            [--protocol {icmp,tcp,udp}]
                                            [--from-port FROM_PORT]
                                            [--to-port TO_PORT]
+                                           [--rules-per-security-group RULES_PER_SECURITY_GROUP]
                                            security-group [security-group ...]
 
 positional arguments:
@@ -48,6 +49,8 @@ optional arguments:
   --from-port FROM_PORT
                         The lowest port on which Pingdom probes
   --to-port TO_PORT     The highest port on which Pingdom probes
+  --rules-per-security-group RULES_PER_SECURITY_GROUP
+                        The maximum number of rules per security group
 ```
 
 Note that your environment must be configured to provide valid AWS credentials.


### PR DESCRIPTION
Previously we would hardcode a maximum of 50 rules per security group. This was
wrong for two reasons:
- AWS has since increased the default to 60 rules per security group.
- AWS [allows][1] this limit to be increased further.

Fixes #8.

[1]: https://aws.amazon.com/premiumsupport/knowledge-center/increase-security-group-rule-limit/